### PR TITLE
Add -E (present since 5.1.8 according to manpage)

### DIFF
--- a/files/dump_db.sh
+++ b/files/dump_db.sh
@@ -2,4 +2,4 @@
 DIR=/var/backups/mariadb/
 [ -d $DIR ] || mkdir -p $DIR
 
-mysqldump --all-databases > $DIR/dump.sql
+mysqldump --all-databases -E > $DIR/dump.sql


### PR DESCRIPTION
mysqldump is sending me daily mail about the fact that
without -E, it doesn't dump the event base:
```
  -- Warning: Skipping the data of table mysql.event. Specify the --events option explicitly.
```
So the option are either to filter that message, or add the option.
Since scheduled events would matter in some case, it
is better to have them in the backups.