### PR TITLE
Correct Python 3 check

### DIFF
--- a/vars/sys_RedHat_mariadb.yml
+++ b/vars/sys_RedHat_mariadb.yml
@@ -1,7 +1,7 @@
 ---
 rdbms_packages:
   - mariadb-server
-  - "{{ (ansible_python_interpreter | search('python3')) | ternary('python3-mysql', 'MySQL-python') }}"
+  - "{{ (ansible_python['version']['major'] == 3) | ternary('python3-mysql', 'MySQL-python') }}"
 rdbms_service: mariadb
 log_file: /var/log/mariadb/mariadb.log
 socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
ansible_python_interpreter is only set when overriding the default
interpreter.