### PR TITLE
Fix failure on Fedora 27

### DIFF
--- a/templates/my.client.cnf
+++ b/templates/my.client.cnf
@@ -1,4 +1,4 @@
 [client]
-user = root
-password = {{ rdbms_root_pw }}
+user=root
+password={{ rdbms_root_pw }}
 


### PR DESCRIPTION
For a reason I didn't found yet, the parser of the python-mysql module
is less forgiving on Fedora than on EL7. And so spaces tend to confuse him,
resulting in "Access denied for user 'root'@'localhost' (using password: NO)"