### PR TITLE
improve CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 ---
 language: python
-python: "2.7"
+dist: bionic
+python: "3.7"
+env:
+  - DEBIAN_FRONTEND=noninteractive
 before_install:
- - sudo apt-get update -qq
+  - sudo apt-get update -qq
+  - sudo apt-get install -y python3-pip
 install:
-  - pip install ansible-lint
+  - pip3 install ansible
+  - pip3 install ansible-lint
 script:
 # verify the syntax of the playbook
   - ansible-lint tasks/main.yml
@@ -17,7 +22,7 @@ script:
 # run a 2nd syntax check ( not sure if ansible-lint shouldn't already do that )
   - ansible-playbook -i '127.0.0.1,' --syntax-check role.yml
 # check that the role can be run
-  - ansible-playbook -i '127.0.0.1,' -c local --sudo -vvvv role.yml
+  - ansible-playbook -i '127.0.0.1,' -c local --become -vvvv role.yml
 # verify idempotence ( ie, running a 2nd time shouldn't change anything )
-  - ansible-playbook -i '127.0.0.1,' -c local --sudo -vvvv role.yml | grep -q 'changed=0.*failed=0'
-  
+  - ansible-playbook -i '127.0.0.1,' -c local --become -vvvv role.yml | grep -q 'changed=0.*failed=0'
+


### PR DESCRIPTION
- using Python 3 with Ansible now
- ensure APT is run in non-interractive mode

It should incidentally work around the recent bug with some earlier
Mariadb version being already installed in the image which led to tests
failure when installing the default version.